### PR TITLE
USB: usbfs: fix potential infoleak in devio

### DIFF
--- a/drivers/usb/core/devio.c
+++ b/drivers/usb/core/devio.c
@@ -1105,10 +1105,11 @@ static int proc_getdriver(struct dev_state *ps, void __user *arg)
 
 static int proc_connectinfo(struct dev_state *ps, void __user *arg)
 {
-	struct usbdevfs_connectinfo ci = {
-		.devnum = ps->dev->devnum,
-		.slow = ps->dev->speed == USB_SPEED_LOW
-	};
+	struct usbdevfs_connectinfo ci;
+
+	memset(&ci, 0, sizeof(ci));
+	ci.devnum = ps->dev->devnum;
+	ci.slow = ps->dev->speed == USB_SPEED_LOW;
 
 	if (copy_to_user(arg, &ci, sizeof(ci)))
 		return -EFAULT;


### PR DESCRIPTION
The stack object “ci” has a total size of 8 bytes. Its last 3 bytes
are padding bytes which are not initialized and leaked to userland
via “copy_to_user”.

Change-Id: Icd49231ee1862682739a871ae78a5602ee104731
Signed-off-by: Kangjie Lu kjlu@gatech.edu
Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
